### PR TITLE
Read from stdin when filename not supplied as $1

### DIFF
--- a/bin/pdfify
+++ b/bin/pdfify
@@ -14,10 +14,11 @@ STYLE="style.css"
 
 TMP=$( mktemp -d )
 BASE_DIR="$(brew --prefix)/opt/pdfify"
-TARGET="$(basename -s md "$1")"
-TARGET_DIR="$(dirname "$1")"
+TARGET="$(basename -s md "${1:-pdfify.}")"
+TARGET_DIR="$(dirname "${1:-.}")"
 
-pandoc "$1" \
+# Read from stdin, if filename not passed as first argument
+pandoc < "${1:-/dev/stdin}" \
     -f markdown_github+header_attributes \
     -t html5 \
     -B "${BASE_DIR}/lib/header.html" \


### PR DESCRIPTION
This PR causes `pdfify` to read from `STDIN` when a filename is not provided at the command-line, e.g. via:

```
pdfify
```

or, via:

```
pdfify --student
```

This allows output from another program to be piped into `pdfify`, e.g. [`mustache`](https://mustache.github.io/mustache.1.html):

```
mustache data.yml template.mustache | pdfify
```

In this case, the PDF will be saved as `pdfify.pdf` in the present working directory.
